### PR TITLE
refactor: derive `Clone` for `InputFile` & `OutputFile`

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -198,7 +198,7 @@ impl FileRead for opendal::Reader {
 }
 
 /// Input file is used for reading from files.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InputFile {
     op: Operator,
     // Absolution path of file.
@@ -280,7 +280,7 @@ impl FileWrite for opendal::Writer {
 }
 
 /// Output file is used for writing to files..
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OutputFile {
     op: Operator,
     // Absolution path of file.


### PR DESCRIPTION
This derives the `Clone` trait for the `InputFile` & `OutputFile` types to allow for creating copies of each.