### PR TITLE
feat(iceberg): omit deleted files within fast-append

### DIFF
--- a/crates/iceberg/src/spec/transform.rs
+++ b/crates/iceberg/src/spec/transform.rs
@@ -144,6 +144,12 @@ impl Transform {
                 match self {
                     Self::Identity => datum.to_string(),
                     Self::Void => "null".to_string(),
+                    // TODO: does this appear anywhere?
+                    //
+                    // It looks like this is used for metrics/statistics, but we hit the todo
+                    // panic otherwise without filling something here.
+                    Self::Day | Self::Month | Self::Year | Self::Hour => datum.to_string(),
+                    Self::Bucket(_) => datum.to_string(),
                     _ => {
                         todo!()
                     }

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -67,8 +67,10 @@ impl<'a> FastAppendAction<'a> {
     pub fn add_data_files(
         &mut self,
         data_files: impl IntoIterator<Item = DataFile>,
+        deleted_data_files: impl IntoIterator<Item = DataFile>,
     ) -> Result<&mut Self> {
-        self.snapshot_produce_action.add_data_files(data_files)?;
+        self.snapshot_produce_action
+            .add_data_files(data_files, deleted_data_files)?;
         Ok(self)
     }
 
@@ -103,13 +105,20 @@ impl<'a> FastAppendAction<'a> {
         )
         .await?;
 
-        self.add_data_files(data_files)?;
+        self.add_data_files(data_files, Vec::new())?;
 
         self.apply().await
     }
 
     /// Finished building the action and apply it to the transaction.
     pub async fn apply(self) -> Result<Transaction<'a>> {
+        if self.snapshot_produce_action.added_data_files.is_empty() {
+            return Err(Error::new(
+                ErrorKind::DataInvalid,
+                "cannot apply no data files to transaction",
+            ));
+        }
+
         // Checks duplicate files
         if self.check_duplicate {
             let new_files: HashSet<&str> = self
@@ -224,7 +233,7 @@ mod tests {
         let table = make_v2_minimal_table();
         let tx = Transaction::new(&table);
         let mut action = tx.fast_append(None, vec![]).unwrap();
-        action.add_data_files(vec![]).unwrap();
+        action.add_data_files(vec![], vec![]).unwrap();
         assert!(action.apply().await.is_err());
     }
 
@@ -245,8 +254,14 @@ mod tests {
             .partition(Struct::from_iter([Some(Literal::string("test"))]))
             .build()
             .unwrap();
-        assert!(action.add_data_files(vec![data_file.clone()]).is_err());
+        assert!(
+            action
+                .add_data_files(vec![data_file.clone(),], vec![])
+                .is_err()
+        );
 
+        let tx = Transaction::new(&table);
+        let mut action = tx.fast_append(None, vec![]).unwrap();
         let data_file = DataFileBuilder::default()
             .content(DataContentType::Data)
             .file_path("test/3.parquet".to_string())
@@ -257,7 +272,9 @@ mod tests {
             .partition(Struct::from_iter([Some(Literal::long(300))]))
             .build()
             .unwrap();
-        action.add_data_files(vec![data_file.clone()]).unwrap();
+        action
+            .add_data_files(vec![data_file.clone()], vec![])
+            .unwrap();
         let tx = action.apply().await.unwrap();
 
         // check updates and requirements

--- a/crates/iceberg/src/transaction/append.rs
+++ b/crates/iceberg/src/transaction/append.rs
@@ -256,7 +256,7 @@ mod tests {
             .unwrap();
         assert!(
             action
-                .add_data_files(vec![data_file.clone(),], vec![])
+                .add_data_files(vec![data_file.clone()], vec![])
                 .is_err()
         );
 

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -274,7 +274,8 @@ impl<'a> SnapshotProduceAction<'a> {
                     .any(|entry| deleted_file_paths.contains(entry.file_path()));
 
                 if has_deleted_entries {
-                    // Need to rewrite this manifest without the deleted entries
+                    // When there are deleted files, we should write the new manifests
+                    // of this snapshot without including those entries.
                     let mut writer = {
                         let builder = ManifestWriterBuilder::new(
                             self.new_manifest_output()?,

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::ops::RangeFrom;
 
@@ -253,24 +253,68 @@ impl<'a> SnapshotProduceAction<'a> {
         }
 
         if !self.added_delete_files.is_empty() {
-            let deleted_file_paths_to_idx: HashMap<&str, usize> = HashMap::from_iter(
-                self.added_delete_files
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, d)| (d.file_path(), idx)),
-            );
-            for manifest in existing_manifests.clone() {
-                let manifest_entry = manifest
+            let deleted_file_paths: HashSet<String> = self
+                .added_delete_files
+                .iter()
+                .map(|df| df.file_path.clone())
+                .collect();
+
+            // Filter existing manifests to remove entries for deleted files
+            let mut filtered_manifests = Vec::new();
+
+            for manifest in existing_manifests {
+                let manifest_entries = manifest
                     .load_manifest(self.tx.current_table.file_io())
                     .await?;
-                for entry in manifest_entry.entries() {
-                    if let Some(idx) = deleted_file_paths_to_idx.get(entry.data_file.file_path()) {
-                        // Do not include the data (parquet) file in the existing manifest list
-                        // if it has been known to be removed.
-                        existing_manifests.swap_remove(*idx);
+
+                // Check if any entries in this manifest are for deleted files
+                let has_deleted_entries = manifest_entries
+                    .entries()
+                    .iter()
+                    .any(|entry| deleted_file_paths.contains(entry.file_path()));
+
+                if has_deleted_entries {
+                    // Need to rewrite this manifest without the deleted entries
+                    let mut writer = {
+                        let builder = ManifestWriterBuilder::new(
+                            self.new_manifest_output()?,
+                            Some(self.snapshot_id),
+                            self.key_metadata.clone(),
+                            self.tx.current_table.metadata().current_schema().clone(),
+                            self.tx
+                                .current_table
+                                .metadata()
+                                .default_partition_spec()
+                                .as_ref()
+                                .clone(),
+                        );
+                        if self.tx.current_table.metadata().format_version() == FormatVersion::V1 {
+                            builder.build_v1()
+                        } else {
+                            builder.build_v2_data()
+                        }
+                    };
+
+                    for entry in manifest_entries.entries() {
+                        // Skip the deleted entry so it does not show up in
+                        // the latest snapshot that is generated.
+                        if deleted_file_paths.contains(entry.file_path()) {
+                            continue;
+                        }
+                        writer.add_entry(entry.as_ref().clone())?;
                     }
+
+                    let new_manifest = writer.write_manifest_file().await?;
+                    filtered_manifests.push(new_manifest);
+                } else {
+                    // No deleted entries in this manifest, keep it as-is
+                    filtered_manifests.push(manifest);
                 }
             }
+
+            // Replace the existing manifests with our modified list
+            // which omits the known deleted data (parquet) files.
+            existing_manifests = filtered_manifests;
         }
         let manifest_files = manifest_process.process_manifests(existing_manifests);
         Ok(manifest_files)

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -251,22 +251,22 @@ impl<'a> SnapshotProduceAction<'a> {
         }
 
         if !self.added_delete_files.is_empty() {
+            let deleted_file_paths_to_idx: HashMap<&str, usize> = HashMap::from_iter(
+                self.added_delete_files
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, d)| (d.file_path(), idx)),
+            );
             for manifest in existing_manifests.clone() {
                 let manifest_entry = manifest
                     .load_manifest(self.tx.current_table.file_io())
                     .await?;
                 for entry in manifest_entry.entries() {
-                    // HACK: this will be quite slow.
-                    let idx = if let Some(idx) = self
-                        .added_delete_files
-                        .iter()
-                        .position(|d| d.file_path == entry.data_file.file_path)
-                    {
-                        idx
-                    } else {
-                        continue;
-                    };
-                    existing_manifests.swap_remove(idx);
+                    if let Some(idx) = deleted_file_paths_to_idx.get(entry.data_file.file_path()) {
+                        // Do not include the data (parquet) file in the existing manifest list
+                        // if it has been known to be removed.
+                        existing_manifests.swap_remove(*idx);
+                    }
                 }
             }
         }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -130,14 +130,14 @@ impl<'a> SnapshotProduceAction<'a> {
         data_files: impl IntoIterator<Item = DataFile>,
         deleted_data_files: impl IntoIterator<Item = DataFile>,
     ) -> Result<&mut Self> {
-        for data_file in data_files {
+        let data_files: Vec<DataFile> = data_files.into_iter().collect();
+        for data_file in &data_files {
             if data_file.content_type() != crate::spec::DataContentType::Data {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     "Only data content type is allowed for fast append",
                 ));
             }
-            self.added_data_files.push(data_file.clone());
 
             // Check if the data file partition spec id matches the table default partition spec id.
             if self.tx.current_table.metadata().default_partition_spec_id()
@@ -154,9 +154,8 @@ impl<'a> SnapshotProduceAction<'a> {
             )?;
         }
 
-        for data_file in deleted_data_files {
-            self.added_delete_files.push(data_file.clone());
-
+        let deleted_data_files: Vec<DataFile> = deleted_data_files.into_iter().collect();
+        for data_file in &deleted_data_files {
             // Check if the data file partition spec id matches the table default partition spec id.
             if self.tx.current_table.metadata().default_partition_spec_id()
                 != data_file.partition_spec_id
@@ -171,6 +170,8 @@ impl<'a> SnapshotProduceAction<'a> {
                 self.tx.current_table.metadata().default_partition_type(),
             )?;
         }
+        self.added_data_files.extend(data_files);
+        self.added_delete_files.extend(deleted_data_files);
         Ok(self)
     }
 
@@ -191,7 +192,8 @@ impl<'a> SnapshotProduceAction<'a> {
 
     // Write manifest file for added data files and return the ManifestFile for ManifestList.
     async fn write_added_manifest(&mut self) -> Result<ManifestFile> {
-        if self.added_data_files.is_empty() {
+        let added_data_files = std::mem::take(&mut self.added_data_files);
+        if added_data_files.is_empty() {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,
                 "No added data files found when write a manifest file",
@@ -200,7 +202,7 @@ impl<'a> SnapshotProduceAction<'a> {
 
         let snapshot_id = self.snapshot_id;
         let format_version = self.tx.current_table.metadata().format_version();
-        let manifest_entries = self.added_data_files.clone().into_iter().map(|data_file| {
+        let manifest_entries = added_data_files.into_iter().map(|data_file| {
             let builder = ManifestEntry::builder()
                 .status(crate::spec::ManifestStatus::Added)
                 .data_file(data_file);

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -24,11 +24,10 @@ use uuid::Uuid;
 use crate::error::Result;
 use crate::io::OutputFile;
 use crate::spec::{
-    DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestEntry,
-    ManifestFile, ManifestListWriter, ManifestWriterBuilder, Operation,
-    PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT, PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT,
-    Snapshot, SnapshotReference, SnapshotRetention, SnapshotSummaryCollector, Struct, StructType,
-    Summary, update_snapshot_summaries,
+    DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestEntry, ManifestFile,
+    ManifestListWriter, ManifestWriterBuilder, Operation, PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT,
+    PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT, Snapshot, SnapshotReference, SnapshotRetention,
+    SnapshotSummaryCollector, Struct, StructType, Summary, update_snapshot_summaries,
 };
 use crate::transaction::Transaction;
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
@@ -247,17 +246,30 @@ impl<'a> SnapshotProduceAction<'a> {
         let mut existing_manifests = snapshot_produce_operation.existing_manifest(self).await?;
 
         if !self.added_data_files.is_empty() {
-            let added_data_files = std::mem::take(&mut self.added_data_files);
-            let added_manifest = self.write_added_manifest(added_data_files).await?;
+            let added_manifest = self.write_added_manifest().await?;
             existing_manifests.push(added_manifest);
         }
 
         if !self.added_delete_files.is_empty() {
-            let added_delete_files = std::mem::take(&mut self.added_delete_files);
-            let added_manifest = self.write_added_manifest(added_delete_files).await?;
-            existing_manifests.push(added_manifest);
+            for manifest in existing_manifests.clone() {
+                let manifest_entry = manifest
+                    .load_manifest(self.tx.current_table.file_io())
+                    .await?;
+                for entry in manifest_entry.entries() {
+                    // HACK: this will be quite slow.
+                    let idx = if let Some(idx) = self
+                        .added_delete_files
+                        .iter()
+                        .position(|d| d.file_path == entry.data_file.file_path)
+                    {
+                        idx
+                    } else {
+                        continue;
+                    };
+                    existing_manifests.swap_remove(idx);
+                }
+            }
         }
-
         let manifest_files = manifest_process.process_manifests(existing_manifests);
         Ok(manifest_files)
     }

--- a/crates/iceberg/src/transaction/snapshot.rs
+++ b/crates/iceberg/src/transaction/snapshot.rs
@@ -24,10 +24,11 @@ use uuid::Uuid;
 use crate::error::Result;
 use crate::io::OutputFile;
 use crate::spec::{
-    DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestEntry, ManifestFile,
-    ManifestListWriter, ManifestWriterBuilder, Operation, PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT,
-    PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT, Snapshot, SnapshotReference, SnapshotRetention,
-    SnapshotSummaryCollector, Struct, StructType, Summary, update_snapshot_summaries,
+    DataFile, DataFileFormat, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestEntry,
+    ManifestFile, ManifestListWriter, ManifestWriterBuilder, Operation,
+    PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT, PROPERTY_WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT,
+    Snapshot, SnapshotReference, SnapshotRetention, SnapshotSummaryCollector, Struct, StructType,
+    Summary, update_snapshot_summaries,
 };
 use crate::transaction::Transaction;
 use crate::{Error, ErrorKind, TableRequirement, TableUpdate};
@@ -66,6 +67,7 @@ pub(crate) struct SnapshotProduceAction<'a> {
     commit_uuid: Uuid,
     snapshot_properties: HashMap<String, String>,
     pub added_data_files: Vec<DataFile>,
+    pub added_delete_files: Vec<DataFile>,
     // A counter used to generate unique manifest file names.
     // It starts from 0 and increments for each new manifest file.
     // Note: This counter is limited to the range of (0..u64::MAX).
@@ -86,6 +88,7 @@ impl<'a> SnapshotProduceAction<'a> {
             commit_uuid,
             snapshot_properties,
             added_data_files: vec![],
+            added_delete_files: vec![],
             manifest_counter: (0..),
             key_metadata,
         })
@@ -126,15 +129,17 @@ impl<'a> SnapshotProduceAction<'a> {
     pub fn add_data_files(
         &mut self,
         data_files: impl IntoIterator<Item = DataFile>,
+        deleted_data_files: impl IntoIterator<Item = DataFile>,
     ) -> Result<&mut Self> {
-        let data_files: Vec<DataFile> = data_files.into_iter().collect();
-        for data_file in &data_files {
+        for data_file in data_files {
             if data_file.content_type() != crate::spec::DataContentType::Data {
                 return Err(Error::new(
                     ErrorKind::DataInvalid,
                     "Only data content type is allowed for fast append",
                 ));
             }
+            self.added_data_files.push(data_file.clone());
+
             // Check if the data file partition spec id matches the table default partition spec id.
             if self.tx.current_table.metadata().default_partition_spec_id()
                 != data_file.partition_spec_id
@@ -149,7 +154,24 @@ impl<'a> SnapshotProduceAction<'a> {
                 self.tx.current_table.metadata().default_partition_type(),
             )?;
         }
-        self.added_data_files.extend(data_files);
+
+        for data_file in deleted_data_files {
+            self.added_delete_files.push(data_file.clone());
+
+            // Check if the data file partition spec id matches the table default partition spec id.
+            if self.tx.current_table.metadata().default_partition_spec_id()
+                != data_file.partition_spec_id
+            {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Data file partition spec id does not match table default partition spec id",
+                ));
+            }
+            Self::validate_partition_value(
+                data_file.partition(),
+                self.tx.current_table.metadata().default_partition_type(),
+            )?;
+        }
         Ok(self)
     }
 
@@ -170,8 +192,7 @@ impl<'a> SnapshotProduceAction<'a> {
 
     // Write manifest file for added data files and return the ManifestFile for ManifestList.
     async fn write_added_manifest(&mut self) -> Result<ManifestFile> {
-        let added_data_files = std::mem::take(&mut self.added_data_files);
-        if added_data_files.is_empty() {
+        if self.added_data_files.is_empty() {
             return Err(Error::new(
                 ErrorKind::PreconditionFailed,
                 "No added data files found when write a manifest file",
@@ -180,7 +201,7 @@ impl<'a> SnapshotProduceAction<'a> {
 
         let snapshot_id = self.snapshot_id;
         let format_version = self.tx.current_table.metadata().format_version();
-        let manifest_entries = added_data_files.into_iter().map(|data_file| {
+        let manifest_entries = self.added_data_files.clone().into_iter().map(|data_file| {
             let builder = ManifestEntry::builder()
                 .status(crate::spec::ManifestStatus::Added)
                 .data_file(data_file);
@@ -211,6 +232,7 @@ impl<'a> SnapshotProduceAction<'a> {
                 builder.build_v2_data()
             }
         };
+
         for entry in manifest_entries {
             writer.add_entry(entry)?;
         }
@@ -222,14 +244,21 @@ impl<'a> SnapshotProduceAction<'a> {
         snapshot_produce_operation: &OP,
         manifest_process: &MP,
     ) -> Result<Vec<ManifestFile>> {
-        let added_manifest = self.write_added_manifest().await?;
-        let existing_manifests = snapshot_produce_operation.existing_manifest(self).await?;
-        // # TODO
-        // Support process delete entries.
+        let mut existing_manifests = snapshot_produce_operation.existing_manifest(self).await?;
 
-        let mut manifest_files = vec![added_manifest];
-        manifest_files.extend(existing_manifests);
-        let manifest_files = manifest_process.process_manifests(manifest_files);
+        if !self.added_data_files.is_empty() {
+            let added_data_files = std::mem::take(&mut self.added_data_files);
+            let added_manifest = self.write_added_manifest(added_data_files).await?;
+            existing_manifests.push(added_manifest);
+        }
+
+        if !self.added_delete_files.is_empty() {
+            let added_delete_files = std::mem::take(&mut self.added_delete_files);
+            let added_manifest = self.write_added_manifest(added_delete_files).await?;
+            existing_manifests.push(added_manifest);
+        }
+
+        let manifest_files = manifest_process.process_manifests(existing_manifests);
         Ok(manifest_files)
     }
 

--- a/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_data_file_test.rs
@@ -113,7 +113,9 @@ async fn test_append_data_file() {
     // commit result
     let tx = Transaction::new(&table);
     let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
+    append_action
+        .add_data_files(data_file.clone(), vec![])
+        .unwrap();
     let tx = append_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
 
@@ -133,7 +135,9 @@ async fn test_append_data_file() {
     // commit result again
     let tx = Transaction::new(&table);
     let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
+    append_action
+        .add_data_files(data_file.clone(), vec![])
+        .unwrap();
     let tx = append_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
 

--- a/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
+++ b/crates/integration_tests/tests/shared_tests/append_partition_data_file_test.rs
@@ -122,7 +122,7 @@ async fn test_append_partition_data_file() {
     let tx = Transaction::new(&table);
     let mut append_action = tx.fast_append(None, vec![]).unwrap();
     append_action
-        .add_data_files(data_file_valid.clone())
+        .add_data_files(data_file_valid.clone(), vec![])
         .unwrap();
     let tx = append_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
@@ -182,7 +182,7 @@ async fn test_schema_incompatible_partition_type(
     let tx = Transaction::new(&table);
     let mut append_action = tx.fast_append(None, vec![]).unwrap();
     if append_action
-        .add_data_files(data_file_invalid.clone())
+        .add_data_files(data_file_invalid.clone(), vec![])
         .is_ok()
     {
         panic!("diverging partition info should have returned error");
@@ -222,7 +222,7 @@ async fn test_schema_incompatible_partition_fields(
     let tx = Transaction::new(&table);
     let mut append_action = tx.fast_append(None, vec![]).unwrap();
     if append_action
-        .add_data_files(data_file_invalid.clone())
+        .add_data_files(data_file_invalid.clone(), vec![])
         .is_ok()
     {
         panic!("passing different number of partition fields should have returned error");

--- a/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
+++ b/crates/integration_tests/tests/shared_tests/conflict_commit_test.rs
@@ -91,12 +91,16 @@ async fn test_append_data_file_conflict() {
     // start two transaction and commit one of them
     let tx1 = Transaction::new(&table);
     let mut append_action = tx1.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
+    append_action
+        .add_data_files(data_file.clone(), vec![])
+        .unwrap();
     let tx1 = append_action.apply().await.unwrap();
 
     let tx2 = Transaction::new(&table);
     let mut append_action = tx2.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
+    append_action
+        .add_data_files(data_file.clone(), vec![])
+        .unwrap();
     let tx2 = append_action.apply().await.unwrap();
     let table = tx2
         .commit(&rest_catalog)

--- a/crates/integration_tests/tests/shared_tests/scan_all_type.rs
+++ b/crates/integration_tests/tests/shared_tests/scan_all_type.rs
@@ -310,7 +310,9 @@ async fn test_scan_all_type() {
     // commit result
     let tx = Transaction::new(&table);
     let mut append_action = tx.fast_append(None, vec![]).unwrap();
-    append_action.add_data_files(data_file.clone()).unwrap();
+    append_action
+        .add_data_files(data_file.clone(), vec![])
+        .unwrap();
     let tx = append_action.apply().await.unwrap();
     let table = tx.commit(&rest_catalog).await.unwrap();
 


### PR DESCRIPTION
This is a branch off `0.5.1` of `iceberg-rust` which adds some changes to omit deleted files within a fast append action.

It is not currently possible to perform "file-level" deletes via the upstream `iceberg-rust` implementation.This is heavily inspired by [something similar](https://github.com/risingwavelabs/iceberg-rust/commit/1535d0886a3bbf19b0852fee408e9f8623b02ac9) being done by the folks at RisingWave, but has been adapted for an **internal** use case for an interaction with our iceberg exporter and the IOx compactor.